### PR TITLE
Stretch split layouts for centered content

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -212,6 +212,8 @@ body {
 
 .split-row {
     align-items: stretch;
+    flex-wrap: wrap;
+    gap: 0;
 }
 
 .split-column {
@@ -222,18 +224,38 @@ body {
     align-items: stretch;
     height: auto;
     align-self: stretch;
-    flex: 1 1 0;
+    flex: 1 1 100%;
 }
 
 .split-column__inner {
     width: 100%;
     max-width: 32rem;
-    margin: 0 auto;
+    margin-block: auto;
+    margin-inline: auto;
 }
 
 .program-divider {
     display: block;
     width: 100%;
+    height: 2px;
+    background-color: #cbfe19;
+}
+
+.module-column {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2.5rem;
+}
+
+.module-column .module {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.module-column--tight {
+    gap: 1.5rem;
 }
 
 .split-column__inner > .sectionheading,
@@ -267,6 +289,12 @@ body {
         transform: translateY(calc(var(--hero-marquee-height) * 10 + 3rem));
     }
 
+    .split-row > .background-panel,
+    .split-row > .split-column {
+        flex: 1 1 50%;
+        max-width: 50%;
+    }
+
     .split-column {
         padding: 3rem 2.5rem;
         height: 100%;
@@ -297,6 +325,12 @@ body {
 
     .heroimage--mobile {
         display: none;
+    }
+
+    .split-row > .background-panel,
+    .split-row > .split-column {
+        flex: 1 1 50%;
+        max-width: 50%;
     }
 
     .split-column {

--- a/css/main.css
+++ b/css/main.css
@@ -211,10 +211,10 @@ body {
 }
 
 .split-row {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: minmax(0, 1fr);
     align-items: stretch;
-    flex-wrap: wrap;
     gap: 0;
     width: 100%;
     min-height: inherit;
@@ -231,6 +231,12 @@ body {
     align-self: stretch;
     flex: 1 1 100%;
     min-height: 100%;
+    height: 100%;
+}
+
+.split-row > .background-panel,
+.split-row > .split-column {
+    width: 100%;
 }
 
 .split-column__inner {
@@ -281,9 +287,7 @@ body {
 
 @media screen and (min-width: 30em) {
     .split-row {
-        flex-direction: row;
-        align-items: stretch;
-        flex-wrap: nowrap;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .heroimagewrap {
@@ -305,12 +309,6 @@ body {
 
     .hero .hero-social {
         transform: translateY(calc(var(--hero-marquee-height) * 10 + 3rem));
-    }
-
-    .split-row > .background-panel,
-    .split-row > .split-column {
-        flex: 1 1 50%;
-        max-width: 50%;
     }
 
     .split-column {
@@ -343,12 +341,6 @@ body {
 
     .heroimage--mobile {
         display: none;
-    }
-
-    .split-row > .background-panel,
-    .split-row > .split-column {
-        flex: 1 1 50%;
-        max-width: 50%;
     }
 
     .split-column {

--- a/css/main.css
+++ b/css/main.css
@@ -211,9 +211,15 @@ body {
 }
 
 .split-row {
+    display: flex;
+    flex-direction: column;
     align-items: stretch;
     flex-wrap: wrap;
     gap: 0;
+    width: 100%;
+    min-height: inherit;
+    height: 100%;
+    flex: 1 1 auto;
 }
 
 .split-column {
@@ -222,16 +228,21 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
-    height: auto;
     align-self: stretch;
     flex: 1 1 100%;
+    min-height: 100%;
 }
 
 .split-column__inner {
     width: 100%;
     max-width: 32rem;
-    margin-block: auto;
     margin-inline: auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+    height: 100%;
+    flex: 1 1 auto;
 }
 
 .program-divider {
@@ -245,6 +256,7 @@ body {
     display: flex;
     flex-direction: column;
     justify-content: center;
+    flex: 1 1 auto;
     gap: 2.5rem;
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -3,6 +3,10 @@ html {
     font-family: AeonMono;
 }
 
+:root {
+    --hero-marquee-height: 4rem;
+}
+
 .pagecontainer {
     overflow-x: hidden;
 }
@@ -29,7 +33,8 @@ a.active {
 }
 
 .page {
-    height: 100vh;
+    min-height: 100vh;
+    min-height: 100dvh;
 }
 
 .toppage {
@@ -42,8 +47,10 @@ a.active {
     background-size: cover;
     background-attachment: fixed;
     background-repeat: no-repeat;
-    height: 100vh;
-    height: 100dvh;
+    min-height: 100vh;
+    min-height: 100dvh;
+    position: relative;
+    overflow: visible;
 }
 
 .about {
@@ -52,6 +59,17 @@ a.active {
     background-size: cover;
     background-attachment: fixed;
     background-repeat: no-repeat;
+}
+
+.background-panel {
+    min-height: 50vh;
+    align-self: stretch;
+}
+
+@supports (height: 100dvh) {
+    .background-panel {
+        min-height: 50dvh;
+    }
 }
 
 .graham {
@@ -163,21 +181,161 @@ body {
     background-color: black;
 }
 
-.heroimage {
-    height: 100%;
-    overflow: hidden;
+.heroimagewrap {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    pointer-events: none;
+    padding: 1.5rem 1rem 0;
+    gap: 1rem;
+    position: relative;
+    z-index: 2;
+    transform: translateY(var(--hero-marquee-height));
 }
 
-.heroimagemobile {
-    background-image: url(../img/hero.png);
-    background-position: bottom left;
-    background-size: contain;
-    background-repeat: no-repeat;
+.heroimage {
+    max-width: min(90%, 34rem);
+    height: auto;
+    object-fit: contain;
+    object-position: bottom center;
+}
+
+.heroimage--mobile {
+    max-width: 75%;
+    display: block;
+}
+
+.heroimage--desktop {
+    max-width: min(80%, 42rem);
+    display: none;
+}
+
+.split-row {
+    align-items: stretch;
+}
+
+.split-column {
+    padding: 2rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+    height: auto;
+    align-self: stretch;
+    flex: 1 1 0;
+}
+
+.split-column__inner {
+    width: 100%;
+    max-width: 32rem;
+    margin: 0 auto;
+}
+
+.program-divider {
+    display: block;
+    width: 100%;
+}
+
+.split-column__inner > .sectionheading,
+.split-column__inner > .subtitle {
+    display: block;
+}
+
+.split-column__inner.bio {
+    max-width: 34rem;
+}
+
+@media screen and (min-width: 30em) {
+    .heroimagewrap {
+        padding: 2.5rem 2rem 0;
+    }
+
+    .heroimage {
+        max-width: min(80%, 36rem);
+    }
+
+    .heroimage--desktop {
+        max-width: min(70%, 46rem);
+        display: block;
+    }
+
+    .heroimage--mobile {
+        display: none;
+    }
+
+    .hero .hero-social {
+        transform: translateY(calc(var(--hero-marquee-height) * 10 + 3rem));
+    }
+
+    .split-column {
+        padding: 3rem 2.5rem;
+        height: 100%;
+    }
+
+    .split-column__inner {
+        max-width: 34rem;
+    }
+
+    .split-column__inner.bio {
+        max-width: 36rem;
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .heroimagewrap {
+        padding: 3rem 3rem 0;
+    }
+
+    .heroimage {
+        max-width: min(70%, 40rem);
+    }
+
+    .heroimage--desktop {
+        max-width: min(60%, 48rem);
+        display: block;
+    }
+
+    .heroimage--mobile {
+        display: none;
+    }
+
+    .split-column {
+        padding: 4rem 3.5rem;
+        height: 100%;
+    }
+
+    .split-column__inner {
+        max-width: 38rem;
+    }
+
+    .split-column__inner.bio {
+        max-width: 40rem;
+    }
 }
 
 .maincontent {
     flex-grow: 1;
     z-index: 999;
+}
+
+.hero .maincontent {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: clamp(22rem, 55vh, 38rem);
+}
+
+.hero-social {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    min-width: 13rem;
+    transform: translateY(calc(var(--hero-marquee-height) * 4 + 2rem));
+}
+
+.hero-social a {
+    display: block;
 }
 
 .footer {
@@ -225,10 +383,6 @@ a:visited {
         margin-bottom: -0.5rem;
     }
 
-    .page {
-        height: 175vh;
-    }
-
     .heart {
         background-image: url(../img/HEART.png);
         background-position: center center;
@@ -238,13 +392,14 @@ a:visited {
 
     .hero {
         background-image: url(../img/BGTOPMOBILE.png);
-        background-position: left top;
-        background-size: 100% auto;
+        background-position: center top;
+        background-size: cover;
         background-attachment: fixed;
         background-repeat: no-repeat;
-        height: 100vh;
-        height: 100dvh;
+        min-height: 100vh;
+        min-height: 100dvh;
     }
+
 }
 
 @media screen and (min-width: 30em) and (max-width: 60em) {

--- a/css/main.css
+++ b/css/main.css
@@ -280,6 +280,12 @@ body {
 }
 
 @media screen and (min-width: 30em) {
+    .split-row {
+        flex-direction: row;
+        align-items: stretch;
+        flex-wrap: nowrap;
+    }
+
     .heroimagewrap {
         padding: 2.5rem 2rem 0;
     }

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                 <div class="w-50 br bg-yellow"></div><div class="w-50"></div>
             </div>
             <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
-                <div class="w-100 w-50-m w-50-l bb br-m br-l graham background-panel" style="flex-grow: 1;"></div>
+                <div class="w-100 w-50-m w-50-l bb br-m br-l graham background-panel"></div>
                 <div class="flex w-100 w-50-m w-50-l split-column">
                     <div class="flex flex-column split-column__inner bio">
                         <span class="f6 f5-m f5-l mb1 sectionheading">INTRODUCING</span>

--- a/index.html
+++ b/index.html
@@ -17,22 +17,11 @@
     <link rel="stylesheet" href="./css/main.css">
     <link rel="manifest" href="site.webmanifest" />
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <script>
-            window.onload = function () {
-                var height = window.innerHeight;
-                console.log(window.innerHeight);
-                document.getElementsByClassName("hero")[0].style.height = window.innerHeight+"px";
-            }
-    </script>
 </head>
   <body>
     <div class="pagecontainer flex flex-column" style="overflow-x: hidden;">
         <!-- TOP PAGE -->
-        <div class="flex flex-column hero" style="overflow: hidden;">
-            <div class="dn db-m db-l absolute bottom-0 h-100" style="left: 50%; pointer-events: none; overflow: hidden;">
-                <img class="heroimage" src="./img/hero.png" />
-            </div>
-            <div class="heroimagemobile db dn-m dn-l absolute bottom-0 w-60 h-75" style="left: 40%; pointer-events: none;"></div>
+        <div class="flex flex-column hero">
             <div>
                 <div class="h4 w-100 flex items-end bb">
                     <div class="pl3 pl5-m pl5-l f4 f2-l f2-m title" style="margin-bottom: -0.20em;">HOW TO STAY</div>
@@ -44,17 +33,20 @@
                     </div>
                 </div>
             </div>
-            <div class="flex flex-column  maincontent w-100 h4">
+            <div class="flex flex-column maincontent w-100">
                     <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl5-m pl5-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
-                        Human creativity 
+                        Human creativity
                         <span class="white">has never been more important especially in the face of technology.</span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex items-center flex-row pl3 pl5-m pl5-l h4 w-60 w-20-m w-20-l" style="min-width: 208px;">
+                    <div class="flex items-center flex-row pl3 pl5-m pl5-l w-60 w-20-m w-20-l hero-social">
                         <a href="https://open.spotify.com/show/5P6qabdEL76jPmky8eCIWc?si=ed8e0c92cf524fb2" class="h2 w2 social spotify mr3"></a>
                         <a href="https://worldsveryfirst.com" class="h2 w2 social podcast mr3"></a>
                         <a href="https://www.instagram.com/how_to_stay_human/" class="h2 w2 social insta mr3"></a>
                     </div>
+            </div>
+            <div class="heroimagewrap">
+                <img class="heroimage heroimage--desktop dn db-m db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">
                 <div class="bottom-0 bt bb h3 w-100">
@@ -75,29 +67,27 @@
             <div class="flex row bb h3">
                 <div class="w-50 br"></div><div class="w-50"></div>
             </div>
-            <div class="flex flex-column flex-row-m flex-row-l items-end" style="flex-grow: 1;">
-                <div class="h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l heart"></div>
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-90 w-60-m w-60-l">
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="w-100 w-50-m w-50-l bb br-m br-l heart background-panel"></div>
+                <div class="flex w-100 w-50-m w-50-l split-column">
+                    <div class="flex flex-column split-column__inner">
                         <span class="f6 f5-m f5-l mb1 sectionheading">ABOUT</span>
                         <span class="f3 f2-m f2-l mb1 subtitle">CREATIVITY</span>
-                        <span class="f3 f2-m f2-l mb1 subtitle">A 
+                        <span class="f3 f2-m f2-l mb1 subtitle">A
                             <img class="h2 h3-m h3-l" src="./img/HUMANTEXT.png" style="margin-bottom: -0.5rem"></img>
                             EXPERIENCE
                         </span>
                         <span class="mt2 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            As AI starts to play a more significant role in our lives and our creative futures, 
-                            How to Stay Human uncovers practical ways to stay more connected to our humanity and 
+                            As AI starts to play a more significant role in our lives and our creative futures,
+                            How to Stay Human uncovers practical ways to stay more connected to our humanity and
                             more creative because of it.
                             <br /> <br />
-                            Creativity; defined as the human ability to generate new and original ideas and perhaps 
-                            one of the most other-worldly aspects of the human experience. Magical, unstoppable and 
-                            often intangible, it's nothing short of extraordinary. Dr Graham Mead and Maria Devereux 
-                            explore practical ways for us to inspire, enhance and celebrate our creativity. 
+                            Creativity; defined as the human ability to generate new and original ideas and perhaps
+                            one of the most other-worldly aspects of the human experience. Magical, unstoppable and
+                            often intangible, it's nothing short of extraordinary. Dr Graham Mead and Maria Devereux
+                            explore practical ways for us to inspire, enhance and celebrate our creativity.
                         </span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
             </div>
         </div>
@@ -106,11 +96,10 @@
             <div class="flex row bb h3">
                 <div class="w-50 br bg-yellow"></div><div class="w-50"></div>
             </div>
-            <div class="flex flex-column flex-row-m flex-row-l items-end" style="flex-grow: 1;">
-                <div class="h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l graham" style="flex-grow: 1;"></div>
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-90 w-60-m w-60-l bio">
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="w-100 w-50-m w-50-l bb br-m br-l graham background-panel" style="flex-grow: 1;"></div>
+                <div class="flex w-100 w-50-m w-50-l split-column">
+                    <div class="flex flex-column split-column__inner bio">
                         <span class="f6 f5-m f5-l mb1 sectionheading">INTRODUCING</span>
                         <span class="f3 f2-m f2-l mb1 subtitle mb2">DR GRAHAM MEAD</span>
                         <span class="mt2 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
@@ -129,7 +118,6 @@
                             <a href="https://www.grahammead.com/" target="_blank" class="learnmore"></a>
                         </span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
             </div>
         </div>
@@ -138,11 +126,10 @@
             <div class="flex row bb h3">
                 <div class="w-50 br"></div><div class="w-50 bg-yellow"></div>
             </div>
-            <div class="flex flex-column flex-row-m flex-row-l items-end" style="flex-grow: 1;">
-                <div class="h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l maria"></div>
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-90 w-60-m w-60-l bio">
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="w-100 w-50-m w-50-l bb br-m br-l maria background-panel"></div>
+                <div class="flex w-100 w-50-m w-50-l split-column">
+                    <div class="flex flex-column split-column__inner bio">
                         <span class="f6 f5-m f5-l mb1 sectionheading">INTRODUCING</span>
                         <span class="f3 f2-m f2-l mb1 subtitle mb2">MARIA DEVEREUX</span>
                         <span class="mt2 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
@@ -159,7 +146,6 @@
                             <a href="https://www.mariadevereux.com" target="_blank" class="learnmore"></a>
                         </span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
             </div>
         </div>

--- a/podcast.html
+++ b/podcast.html
@@ -29,24 +29,12 @@
             }
         }
     </style>
-    <script>
-        window.onload = function () {
-            var height = window.innerHeight;
-            console.log(window.innerHeight);
-            document.getElementsByClassName("hero")[0].style.height = window.innerHeight + "px";
-        }
-    </script>
 </head>
 
 <body>
     <div class="pagecontainer flex flex-column" style="overflow-x: hidden;">
         <!-- TOP PAGE -->
         <div class="flex flex-column page hero">
-            <div class="dn db-m db-l absolute bottom-0 h-100" style="left: 50%; pointer-events: none;">
-                <img class="heroimage" src="./img/hero.png" />
-            </div>
-            <div class="heroimagemobile dn-m dn-l absolute bottom-0 h-75 w-60" style="left: 40%; pointer-events: none;">
-            </div>
             <div>
                 <div class="h4 w-100 flex items-end bb">
                     <div class="pl3 pl5-m pl5-l f4 f2-l f2-m title" style="margin-bottom: -0.20em;">HOW TO STAY</div>
@@ -58,18 +46,21 @@
                     </div>
                 </div>
             </div>
-            <div class="flex flex-column  maincontent w-100 h4">
+            <div class="flex flex-column maincontent w-100">
                 <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl5-m pl5-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
                     Human creativity
                     <span class="white">has never been more important especially in the face of technology.</span>
                 </div>
-                <div style="flex-grow: 1;"></div>
-                <div class="flex items-center flex-row pl3 pl5-m pl5-l h4 w-60 w-20-m w-20-l" style="min-width: 208px;">
+                <div class="flex items-center flex-row pl3 pl5-m pl5-l w-60 w-20-m w-20-l hero-social">
                     <a href="https://open.spotify.com/show/5P6qabdEL76jPmky8eCIWc?si=ed8e0c92cf524fb2"
                         class="h2 w2 social spotify mr3"></a>
                     <a href="https://worldsveryfirst.com" class="h2 w2 social podcast mr3"></a>
                     <a href="https://www.instagram.com/how_to_stay_human/" class="h2 w2 social insta mr3"></a>
                 </div>
+            </div>
+            <div class="heroimagewrap">
+                <img class="heroimage heroimage--desktop dn db-m db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">
                 <div class="bottom-0 bt bb h3 w-100">
@@ -89,17 +80,17 @@
         </div>
         <!-- 2ND PAGE - ABOUT -->
         <div class="flex flex-column bb">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE ONE</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">DEXTON DEBOREE</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">WHAT CREATIVITY FEELS
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE ONE</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">DEXTON DEBOREE</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">WHAT CREATIVITY FEELS
                             LIKE</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
                         Dexton is part visionary, strategist, content pioneer, diversely talented
                         Writer/Director/Producer and creative hybrid.
                         <br /><br />
@@ -112,8 +103,8 @@
                         award-winning Feature Film, “Unbanned: The Legend of AJ1”, the 6-Part Series Best Shape of My
                         Life, starring Will Smith, and many other award winning TV Series and Feature Films.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/6dgbov8HgsZcttxzepb4iQ?utm_source=generator"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
@@ -125,26 +116,26 @@
 
         
         <div class="flex flex-column bb bg-yellow">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE TWO</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">ARI KUSHNIR</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">HOW CREATIVITY CAN IMAGINE A BETTER WORLD</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE TWO</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">ARI KUSHNIR</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">HOW CREATIVITY CAN IMAGINE A BETTER WORLD</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
-                        Dr Graham Mead and Maria Devereux explore the power of AI to imagine a better world with Ari Kuschnir. 
-                        Ari is a visionary and creative catalyst who consistently pushes the boundaries of 
-                        contemporary storytelling. 
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                        Dr Graham Mead and Maria Devereux explore the power of AI to imagine a better world with Ari Kuschnir.
+                        Ari is a visionary and creative catalyst who consistently pushes the boundaries of
+                        contemporary storytelling.
                         <br /><br />
-                        He is the founder of award-winning production company M ss ng P eces. But Ari recently became an 
-                        online sensation, with billions of views of his mind-bending viral AI videos which spark joy 
+                        He is the founder of award-winning production company M ss ng P eces. But Ari recently became an
+                        online sensation, with billions of views of his mind-bending viral AI videos which spark joy
                         and wonder, planting seeds in the collective imagination that a different world is possible.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/4uKBfuSrxFqimKvB2a4WPk?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -155,24 +146,24 @@
 
 
         <div class="flex flex-column bb">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE THREE</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">TAMI NEILSON</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">TO BE COMPELLED TO CREATE IS TO BE HUMAN</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE THREE</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">TAMI NEILSON</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">TO BE COMPELLED TO CREATE IS TO BE HUMAN</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
-                        Dr Graham Mead and Maria Devereux explore why humans are compelled to create with Tami Neilson. As an 
-                        award-winning country and soul musician, Tami shares the mystical and sometimes vulnerable 
-                        creative process of making music and performing in front of a crowd. Having just finished 
-                        touring with Willie Nelson, Bob Dylan and The Avett Brothers, Tami's latest album 'Neon Cowgirl' 
-                        has already made it to number ten in the US charts. 
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                        Dr Graham Mead and Maria Devereux explore why humans are compelled to create with Tami Neilson. As an
+                        award-winning country and soul musician, Tami shares the mystical and sometimes vulnerable
+                        creative process of making music and performing in front of a crowd. Having just finished
+                        touring with Willie Nelson, Bob Dylan and The Avett Brothers, Tami's latest album 'Neon Cowgirl'
+                        has already made it to number ten in the US charts.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/0QBSYQG3ie7aZelw502Lv4?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -182,23 +173,23 @@
         </div>
 
         <div class="flex flex-column bb bg-yellow">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE FOUR</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">PAUL RAPHAËL</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">HOW REAL SHOULD VIRTUAL REALITY BE?</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE FOUR</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">PAUL RAPHAËL</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">HOW REAL SHOULD VIRTUAL REALITY BE?</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
-                        Dr Graham Mead and Maria Devereux explore how real virtual reality should be with Paul Raphaël. Paul is an 
-                        Emmy award-winning and Oscar-nominated filmmaker, visual artist and director. He is widely recognized 
-                        as an immersive entertainment revolutionary. Alongside his co-founder Felix Lajeunesse, he has revolutionized 
-                        VR, AR, and mixed reality entertainment since the inception of Felix & Paul Studios in 2013. 
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                        Dr Graham Mead and Maria Devereux explore how real virtual reality should be with Paul Raphaël. Paul is an
+                        Emmy award-winning and Oscar-nominated filmmaker, visual artist and director. He is widely recognized
+                        as an immersive entertainment revolutionary. Alongside his co-founder Felix Lajeunesse, he has revolutionized
+                        VR, AR, and mixed reality entertainment since the inception of Felix & Paul Studios in 2013.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/7wRHD4j2hT5HUvATLsnz87?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -208,23 +199,23 @@
         </div>
 
         <div class="flex flex-column bb">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE FIVE</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">SCOTT LEESE</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">THE AI PROMPT IS A HUMAN CHOICE</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE FIVE</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">SCOTT LEESE</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">THE AI PROMPT IS A HUMAN CHOICE</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
                         Dr Graham Mead, Maria Devereux and Scott Leese explore how the power of human choice influences our interaction with AI.
                         Scott is a six times Sales Leader, five times Founder and three times Amazon best-selling Author. With numerous industry
                         awards for excellence in sales leadership, he is a top start up sales leader in the US and a respected strategic advisor
                         to companies all around the world.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/4yEopczRbGDIOpO8F36F74?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -235,23 +226,23 @@
 
     
         <div class="flex flex-column bb bg-yellow">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE SIX</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">MATTHEW HARTMAN</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">CAN TECHNOLOGY BE HUMAN?</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE SIX</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">MATTHEW HARTMAN</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">CAN TECHNOLOGY BE HUMAN?</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
                         Dr Graham Mead and Maria Devereux explore whether technology can be human with Matt Hartman. Matt is Managing Partner of
                         Factorial Capital where he led the first investment rounds in multi billion dollar company, Huggingface. And in Anchor,
                         the popular podcast app acquired by Spotify. With a proven track record, Matt founded this new model in venture capital
                         to invest in the next generation of AI startups.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/2moz6XJG4Lz142oH1kPGjz?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -261,23 +252,23 @@
         </div>
 
         <div class="flex flex-column bb">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE SEVEN</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">FRANZ RIEBENBAUER</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">WHY CREATIVITY THRIVES IN UNCERTAINTY?</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner pl3 pl5-m pl5-l">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE SEVEN</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">FRANZ RIEBENBAUER</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">WHY CREATIVITY THRIVES IN UNCERTAINTY?</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
                         Dr Graham Mead and Maria Devereux explore why creativity thrives in uncertainty with Franz Riebenbauer. Franz is an
                         award-winning designer and the Founder of multidisciplinary design studio, Studio Riebenbauer. With a vision to build a
                         studio that sees brands as living ecosystems, for over two decades Franz has created revolutionary immersive brand
                         experiences which use design as a tool to shape memory, emotion, and deeper human connection.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/4GYG1FuEvZdMahUwizfd7t?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -287,23 +278,23 @@
         </div>
 
         <div class="flex flex-column bb bg-yellow">
-            <div class="flex flex-column flex-row-m flex-row-l items-around" style="flex-grow: 1;">
-                <div class="flex h-50 w-100 w-40-m w-40-l h-100-m h-100-l">
-                    <div class="flex pt5 flex-column w-90 w-100-m w-100-l">
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">EPISODE EIGHT</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f3 f2-m f2-l mb1 subtitle">RIMMA BOSHERNITSAN</span>
-                        <span class="w-100 pl3 pl5-m pl5-l f6 f5-m f5-l mb1 sectionheading">THE TRUE POWER OF CREATIVE INTUITION</span>
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-40-m w-40-l split-column">
+                    <div class="split-column__inner">
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">EPISODE EIGHT</span>
+                        <span class="w-100 f3 f2-m f2-l mb1 subtitle">RIMMA BOSHERNITSAN</span>
+                        <span class="w-100 f6 f5-m f5-l mb1 sectionheading">THE TRUE POWER OF CREATIVE INTUITION</span>
                     </div>
                 </div>
-                <div class="flex flex-column items-center h-50 w-100 w-60-m h-100-m w-60-l h-100-l">
-                    <div class="w-90 f6 f5-m f5-l sectionbody pv3 pv4-m pv4-l lh-copy">
+                <div class="flex flex-column w-100 w-60-m w-60-l split-column">
+                    <div class="split-column__inner">
                         Dr Graham Mead and Maria Devereux explore the true power of creative intuition with Rimma Boshernitsan. Rimma is the
                         founder and CEO of DIALOGUE, an interdisciplinary strategic advisory which sits at the intersection of technology, human
                         connection and strategy. Over her 20-year career, she has served as a strategic advisor and thought partner to CEOs of
                         emerging businesses and Fortune 500 organizations including Google, Apple and Levi's.
                     </div>
-                    <div class="w-90 pb3">
-                        <iframe class="w-100 w-75-m w-75-l" data-testid="embed-iframe" style="border-radius:12px"
+                    <div class="split-column__inner pt3">
+                        <iframe class="w-100" data-testid="embed-iframe" style="border-radius:12px"
                             src="https://open.spotify.com/embed/episode/2jtAtdgW7W76NizVqYu8n1?utm_source=generator&theme=0" width="100%"
                             height="152" frameBorder="0" allowfullscreen=""
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>

--- a/programs.html
+++ b/programs.html
@@ -127,41 +127,40 @@
         <!-- 3RD PAGE - 30 MINUTE PROGRAMS -->
         <div class="flex flex-column page bb">
             <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
-                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
-                    style="flex-grow: 1;">
+                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column">
                     <div class="flex flex-column split-column__inner bio tc">
                         <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
                         <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
                     </div>
                 </div>
                 <div class="flex w-100 w-50-m w-50-l pv4 split-column">
-                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio split-column__inner">
-                        <div style="flex-grow: 1;"></div>
-                        <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE ONE</span>
-                        <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow"> SUPERCHARGING YOUR
-                            CREATIVE MIND</span>
-                        <span class="mt2 w-80 ph3 ph5-m ph5-l f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            Reigning in the mind: The benefit of becoming still in theory and in practice.
-                            Experience a sense of being, a clearing of the mind for optimal function and better sleep.
-                            Changing the trajectory of thought to identify and intercept redundant or addictive
-                            patterns of thinking.
-                        </span>
-                        <div style="flex-grow: 1;"></div>
-                        <span class="w-100 bb yellow mv4 program-divider"></span>
-                        <div style="flex-grow: 1;"></div>
-                        <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE TWO</span>
-                        <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">SELF
-                            RESPONSIBILITY</span>
-                        <span class="mt2 mb3 w-80 ph3 ph5-m ph5-l f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            Practical development of emotional IQ and accountability. Looking inward at the source of
-                            our
-                            reactions rather than simply outward at our triggers.
-                            Experience the importance of integrity, courage and humility, honesty and truth, a
-                            willingness
-                            to 'feel', and how responding consciously to challenges can overcome default nervous system
-                            tendencies.
-                        </span>
-                        <div style="flex-grow: 1;"></div>
+                    <div class="split-column__inner bio module-column">
+                        <div class="module w-80 ph3 ph5-m ph5-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow">MODULE ONE</span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2 yellow"> SUPERCHARGING YOUR
+                                CREATIVE MIND</span>
+                            <span class="mt2 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
+                                Reigning in the mind: The benefit of becoming still in theory and in practice.
+                                Experience a sense of being, a clearing of the mind for optimal function and better sleep.
+                                Changing the trajectory of thought to identify and intercept redundant or addictive
+                                patterns of thinking.
+                            </span>
+                        </div>
+                        <span class="program-divider" aria-hidden="true"></span>
+                        <div class="module w-80 ph3 ph5-m ph5-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow">MODULE TWO</span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2 yellow">SELF
+                                RESPONSIBILITY</span>
+                            <span class="mt2 mb0 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
+                                Practical development of emotional IQ and accountability. Looking inward at the source of
+                                our
+                                reactions rather than simply outward at our triggers.
+                                Experience the importance of integrity, courage and humility, honesty and truth, a
+                                willingness
+                                to 'feel', and how responding consciously to challenges can overcome default nervous system
+                                tendencies.
+                            </span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -170,34 +169,33 @@
         <div class="flex flex-column page nosign" style="overflow-x: hidden;">
             <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
                 <div class="flex w-100 w-50-m w-50-l bb bn-m bn-l pv4 split-column">
-                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio split-column__inner">
-                        <div style="flex-grow: 1;"></div>
-                        <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE THREE</span>
-                        <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">HUMAN
-                            RELATIONSHIP</span>
-                        <span class="mt2 w-80 ph3 ph5-m ph5-l f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            Self-awareness, self-responsibility and freedom through relationship.
-                            Experience clarity in how to utilize relationship as a powerful and consistent catalyst
-                            for internal growth, deep insight into your own humanity and a way of liberating your
-                            creativity energy
-                        </span>
-                        <div style="flex-grow: 1;"></div>
-                        <span class="w-100 bb yellow mv4 program-divider"></span>
-                        <div style="flex-grow: 1;"></div>
-                        <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE FOUR</span>
-                        <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">HUMAN RESOURCE</span>
-                        <span class="mt2 mb3 w-80 ph3 ph5-m ph5-l f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            Nurturing the body to settle the mind.
-                            Experience wholesome, sustainable ways to develop and grow your own internal creative energy
-                            resource,
-                            conserving energy, cultivating energy and identifying behaviours that rob you of this
-                            precious human resource.
-                        </span>
-                        <div style="flex-grow: 1;"></div>
+                    <div class="split-column__inner bio module-column">
+                        <div class="module w-80 ph3 ph5-m ph5-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow">MODULE THREE</span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2 yellow">HUMAN
+                                RELATIONSHIP</span>
+                            <span class="mt2 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
+                                Self-awareness, self-responsibility and freedom through relationship.
+                                Experience clarity in how to utilize relationship as a powerful and consistent catalyst
+                                for internal growth, deep insight into your own humanity and a way of liberating your
+                                creativity energy
+                            </span>
+                        </div>
+                        <span class="program-divider" aria-hidden="true"></span>
+                        <div class="module w-80 ph3 ph5-m ph5-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow">MODULE FOUR</span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2 yellow">HUMAN RESOURCE</span>
+                            <span class="mt2 mb0 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
+                                Nurturing the body to settle the mind.
+                                Experience wholesome, sustainable ways to develop and grow your own internal creative energy
+                                resource,
+                                conserving energy, cultivating energy and identifying behaviours that rob you of this
+                                precious human resource.
+                            </span>
+                        </div>
                     </div>
                 </div>
-                <div class="dn flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
-                    style="flex-grow: 1;">
+                <div class="dn flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column">
                     <div class="flex flex-column split-column__inner bio tc">
                         <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
                         <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
@@ -208,47 +206,38 @@
         <!-- 3RD PAGE - GRAHAM -->
         <div class="flex flex-column page nosign bb">
             <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
-                <div class="dn flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
-                    style="flex-grow: 1;">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-100 w-100-m w-100-l bio">
-                        <div class="flex flex-row w-100">
-                            <div style="flex-grow: 1;"></div>
-                            <div class="flex flex-column">
-                                <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
-                                <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
-                            </div>
-                            <div style="flex-grow: 1;"></div>
-                        </div>
+                <div class="dn flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column">
+                    <div class="flex flex-column split-column__inner bio tc">
+                        <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
+                        <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
                 <div class="flex w-100 w-50-m w-50-l pv4 split-column">
-                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio">
-                        <div style="flex-grow: 1;"></div>
-                        <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE FIVE</span>
-                        <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">THE ART OF
-                            OBSERVATION</span>
-                        <span class="mt2 w-80 ph3 ph5-m ph5-l f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            Skillful observation of your mind can lead to improved mental and emotional stability,
-                            energy and creativity.
-                            Experience the nature of authenticity and explore the easeful state at the heart of
-                            non-algorithm-based creativity.
-                        </span>
-                        <div style="flex-grow: 1;"></div>
-                        <span class="w-100 bb yellow mv4 program-divider"></span>
-                        <div style="flex-grow: 1;"></div>
-                        <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow"><a
-                                href="https://grahammead.com/">MODULE SIX</a></span>
-                        <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow"><a
-                                href="https://grahammead.com/">InnerSense. HOW TO STAY
-                                HUMAN IN THE LONG RUN</a></span>
-                        <span class="mt2 mb3 w-80 ph3 ph5-m ph5-l f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
-                            Introduction to the full 9-week self-guided online intensive program.
-                            Experience a developing sense of ease and safety in the body and stability in the mind.
-                            Maintaining openness and a stable connection to our humanity to liberate our creativity
-                        </span>
-                        <div style="flex-grow: 1;"></div>
+                    <div class="split-column__inner bio module-column">
+                        <div class="module w-80 ph3 ph5-m ph5-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow">MODULE FIVE</span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2 yellow">THE ART OF
+                                OBSERVATION</span>
+                            <span class="mt2 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
+                                Skillful observation of your mind can lead to improved mental and emotional stability,
+                                energy and creativity.
+                                Experience the nature of authenticity and explore the easeful state at the heart of
+                                non-algorithm-based creativity.
+                            </span>
+                        </div>
+                        <span class="program-divider" aria-hidden="true"></span>
+                        <div class="module w-80 ph3 ph5-m ph5-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow"><a
+                                    href="https://grahammead.com/">MODULE SIX</a></span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2 yellow"><a
+                                    href="https://grahammead.com/">InnerSense. HOW TO STAY
+                                    HUMAN IN THE LONG RUN</a></span>
+                            <span class="mt2 mb0 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
+                                Introduction to the full 9-week self-guided online intensive program.
+                                Experience a developing sense of ease and safety in the body and stability in the mind.
+                                Maintaining openness and a stable connection to our humanity to liberate our creativity
+                            </span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -258,42 +247,35 @@
             <div class="split-row flex flex-row-m flex-row-l flex-column-reverse flex-column-m flex-column-l"
                 style="flex-grow: 1;">
                 <div class="flex w-100 w-50-m w-50-l split-column">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-90 w-60-m w-60-l bio">
-                        <span class="f6 f5-m f5-l mb1 sectionheading yellow">HOW TO STAY HUMAN</span>
-                        <span class="f3 f2-m f2-l subtitle yellow">THE ULTIMATE</span>
-                        <span class="f3 f2-m f2-l subtitle mb2 yellow">HUMAN EXPERIENCE</span>
-                        <span class="mt2 f6 f5-m f5-l sectionbody lh-solid lh-copy-m lh-copy-l">
-                            Live presentations
-                            <br /><br />
-                            The InnerSense program
-                            <br /><br />
-                            In-person workshops and retreats
-                            <br /><br />
-                            Conscious Leadership programs
-                            <span class="button w4 mt4 flex flex-column">
-                                <a href="mailto:info@howtostayhuman.com" target="_blank" class="learnmore"></a>
+                    <div class="split-column__inner bio module-column module-column--tight">
+                        <div class="module w-90 w-60-m w-60-l">
+                            <span class="f6 f5-m f5-l mb1 sectionheading yellow">HOW TO STAY HUMAN</span>
+                            <span class="f3 f2-m f2-l subtitle yellow">THE ULTIMATE</span>
+                            <span class="f3 f2-m f2-l subtitle mb2 yellow">HUMAN EXPERIENCE</span>
+                            <span class="mt2 f6 f5-m f5-l sectionbody lh-solid lh-copy-m lh-copy-l">
+                                Live presentations
+                                <br /><br />
+                                The InnerSense program
+                                <br /><br />
+                                In-person workshops and retreats
+                                <br /><br />
+                                Conscious Leadership programs
+                                <span class="button w4 mt4 flex flex-column">
+                                    <a href="mailto:info@howtostayhuman.com" target="_blank" class="learnmore"></a>
+                                </span>
                             </span>
-                        </span>
-                    </div>
-                    <div style="flex-grow: 1;"></div>
-                </div>
-                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
-                    style="flex-grow: 1;">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-100 w-100-m w-100-l bio">
-                        <div class="flex flex-row w-100">
-                            <div style="flex-grow: 1;"></div>
-                            <div class="flex flex-column">
-                                <span class="f6 f5-m f5-l mb1 sectionheading">FIND EVENT IN YOUR AREA</span>
-                                <span class="f3 f2-m f2-l mb1 subtitle mb2">IN PERSON WORKSHOPS</span>
-                                <span class="f6 f5-m f5-l mb1 sectionheading"><a
-                                        href="mailto:graham@grahammead.com">FIND OUT MORE</a></span>
-                            </div>
-                            <div style="flex-grow: 1;"></div>
                         </div>
                     </div>
-                    <div style="flex-grow: 1;"></div>
+                </div>
+                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column">
+                    <div class="split-column__inner bio tc">
+                        <div class="module">
+                            <span class="f6 f5-m f5-l mb1 sectionheading">FIND EVENT IN YOUR AREA</span>
+                            <span class="f3 f2-m f2-l mb1 subtitle mb2">IN PERSON WORKSHOPS</span>
+                            <span class="f6 f5-m f5-l mb1 sectionheading"><a
+                                    href="mailto:graham@grahammead.com">FIND OUT MORE</a></span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/programs.html
+++ b/programs.html
@@ -29,24 +29,12 @@
             }
         }
     </style>
-    <script>
-        window.onload = function () {
-            var height = window.innerHeight;
-            console.log(window.innerHeight);
-            document.getElementsByClassName("hero")[0].style.height = window.innerHeight + "px";
-        }
-    </script>
 </head>
 
 <body>
     <div class="pagecontainer flex flex-column" style="overflow-x: hidden;">
         <!-- TOP PAGE -->
         <div class="flex flex-column page hero">
-            <div class="dn db-m db-l absolute bottom-0 h-100" style="left: 50%; pointer-events: none;">
-                <img class="heroimage" src="./img/hero.png" />
-            </div>
-            <div class="heroimagemobile dn-m dn-l absolute bottom-0 h-75 w-60" style="left: 40%; pointer-events: none;">
-            </div>
             <div>
                 <div class="h4 w-100 flex items-end bb">
                     <div class="pl3 pl5-m pl5-l f4 f2-l f2-m title" style="margin-bottom: -0.20em;">HOW TO STAY</div>
@@ -58,18 +46,21 @@
                     </div>
                 </div>
             </div>
-            <div class="flex flex-column  maincontent w-100 h4">
+            <div class="flex flex-column maincontent w-100">
                 <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl5-m pl5-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
                     Human creativity
                     <span class="white">has never been more important especially in the face of technology.</span>
                 </div>
-                <div style="flex-grow: 1;"></div>
-                <div class="flex items-center flex-row pl3 pl5-m pl5-l h4 w-60 w-20-m w-20-l" style="min-width: 208px;">
+                <div class="flex items-center flex-row pl3 pl5-m pl5-l w-60 w-20-m w-20-l hero-social">
                     <a href="https://open.spotify.com/show/5P6qabdEL76jPmky8eCIWc?si=ed8e0c92cf524fb2"
                         class="h2 w2 social spotify mr3"></a>
                     <a href="https://worldsveryfirst.com" class="h2 w2 social podcast mr3"></a>
                     <a href="https://www.instagram.com/how_to_stay_human/" class="h2 w2 social insta mr3"></a>
                 </div>
+            </div>
+            <div class="heroimagewrap">
+                <img class="heroimage heroimage--desktop dn db-m db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">
                 <div class="bottom-0 bt bb h3 w-100">
@@ -99,10 +90,9 @@
                             href="mailto:graham@grahammead.com">CONTACT US</a></span>
                 </div>
             </div>
-            <div class="flex flex-column flex-row-m flex-row-l items-center" style="flex-grow: 1;">
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column pl3 pl5-m pl5-l pr3 pr5-m pr5-l w-100 w-100-m w-100-l">
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-50-m w-50-l split-column">
+                    <div class="flex flex-column split-column__inner pl3 pl5-m pl5-l pr3 pr5-m pr5-l">
                         <span class="f6 f5-m f5-l mb1 sectionheading">HOW TO STAY HUMAN</span>
                         <span class="f3 f2-m f2-l mb1 subtitle">ABOUT OUR PROGRAM</span>
                         <span class="mt3 f6 f5-m f5-l sectionbody lh-copy lh-copy-m lh-copy-l">
@@ -130,31 +120,22 @@
                             </span>
                         </span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
-                <div class="h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb bl-m bl-l picnic"></div>
+                <div class="w-100 w-50-m w-50-l bb bl-m bl-l picnic background-panel"></div>
             </div>
         </div>
         <!-- 3RD PAGE - 30 MINUTE PROGRAMS -->
         <div class="flex flex-column page bb">
-            <div class="flex flex-column flex-row-m flex-row-l items-end" style="flex-grow: 1;">
-                <div class="flex items-center h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l bg-yellow"
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
                     style="flex-grow: 1;">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-100 w-100-m w-100-l bio">
-                        <div class="flex flex-row w-100">
-                            <div style="flex-grow: 1;"></div>
-                            <div class="flex flex-column">
-                                <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
-                                <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
-                            </div>
-                            <div style="flex-grow: 1;"></div>
-                        </div>
+                    <div class="flex flex-column split-column__inner bio tc">
+                        <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
+                        <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l pv4">
-                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio">
+                <div class="flex w-100 w-50-m w-50-l pv4 split-column">
+                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio split-column__inner">
                         <div style="flex-grow: 1;"></div>
                         <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE ONE</span>
                         <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow"> SUPERCHARGING YOUR
@@ -166,7 +147,7 @@
                             patterns of thinking.
                         </span>
                         <div style="flex-grow: 1;"></div>
-                        <span class="w-100 bb yellow mv4"></span>
+                        <span class="w-100 bb yellow mv4 program-divider"></span>
                         <div style="flex-grow: 1;"></div>
                         <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE TWO</span>
                         <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">SELF
@@ -187,9 +168,9 @@
         </div>
         <!-- 4TH PAGE - MARIA -->
         <div class="flex flex-column page nosign" style="overflow-x: hidden;">
-            <div class="flex flex-column flex-row-m flex-row-l items-end" style="flex-grow: 1;">
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l bb bn-m bn-l pv4">
-                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio">
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="flex w-100 w-50-m w-50-l bb bn-m bn-l pv4 split-column">
+                    <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio split-column__inner">
                         <div style="flex-grow: 1;"></div>
                         <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE THREE</span>
                         <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">HUMAN
@@ -201,7 +182,7 @@
                             creativity energy
                         </span>
                         <div style="flex-grow: 1;"></div>
-                        <span class="w-100 bb yellow mv4"></span>
+                        <span class="w-100 bb yellow mv4 program-divider"></span>
                         <div style="flex-grow: 1;"></div>
                         <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE FOUR</span>
                         <span class="f3 f2-m f2-l mb1 w-80 ph3 ph5-m ph5-l subtitle mb2 yellow">HUMAN RESOURCE</span>
@@ -215,27 +196,19 @@
                         <div style="flex-grow: 1;"></div>
                     </div>
                 </div>
-                <div class="dn flex-m flex-l items-center h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l bg-yellow"
+                <div class="dn flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
                     style="flex-grow: 1;">
-                    <div style="flex-grow: 1;"></div>
-                    <div class="flex flex-column w-100 w-100-m w-100-l bio">
-                        <div class="flex flex-row w-100">
-                            <div style="flex-grow: 1;"></div>
-                            <div class="flex flex-column">
-                                <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
-                                <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
-                            </div>
-                            <div style="flex-grow: 1;"></div>
-                        </div>
+                    <div class="flex flex-column split-column__inner bio tc">
+                        <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
+                        <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
                     </div>
-                    <div style="flex-grow: 1;"></div>
                 </div>
             </div>
         </div>
         <!-- 3RD PAGE - GRAHAM -->
         <div class="flex flex-column page nosign bb">
-            <div class="flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
-                <div class="dn flex-m flex-l items-center h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l bg-yellow"
+            <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
+                <div class="dn flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
                     style="flex-grow: 1;">
                     <div style="flex-grow: 1;"></div>
                     <div class="flex flex-column w-100 w-100-m w-100-l bio">
@@ -250,7 +223,7 @@
                     </div>
                     <div style="flex-grow: 1;"></div>
                 </div>
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l pv4">
+                <div class="flex w-100 w-50-m w-50-l pv4 split-column">
                     <div class="flex flex-column h-100 w-100 w-100-m w-100-l bio">
                         <div style="flex-grow: 1;"></div>
                         <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow">MODULE FIVE</span>
@@ -263,7 +236,7 @@
                             non-algorithm-based creativity.
                         </span>
                         <div style="flex-grow: 1;"></div>
-                        <span class="w-100 bb yellow mv4"></span>
+                        <span class="w-100 bb yellow mv4 program-divider"></span>
                         <div style="flex-grow: 1;"></div>
                         <span class="f6 f5-m f5-l mb1 w-80 ph3 ph5-m ph5-l sectionheading yellow"><a
                                 href="https://grahammead.com/">MODULE SIX</a></span>
@@ -282,9 +255,9 @@
         </div>
         <!-- 4TH PAGE - MARIA -->
         <div class="flex flex-column page" style="overflow-x: hidden;">
-            <div class="flex flex-row-m flex-row-l items-end flex-column-reverse flex-column-m flex-column-l"
+            <div class="split-row flex flex-row-m flex-row-l flex-column-reverse flex-column-m flex-column-l"
                 style="flex-grow: 1;">
-                <div class="flex items-center h-50 w-100 w-50-m w-50-l h-100-m h-100-l">
+                <div class="flex w-100 w-50-m w-50-l split-column">
                     <div style="flex-grow: 1;"></div>
                     <div class="flex flex-column w-90 w-60-m w-60-l bio">
                         <span class="f6 f5-m f5-l mb1 sectionheading yellow">HOW TO STAY HUMAN</span>
@@ -305,7 +278,7 @@
                     </div>
                     <div style="flex-grow: 1;"></div>
                 </div>
-                <div class="flex items-center h-50 w-100 w-50-m h-100-m w-50-l h-100-l bb br-m br-l bg-yellow"
+                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column"
                     style="flex-grow: 1;">
                     <div style="flex-grow: 1;"></div>
                     <div class="flex flex-column w-100 w-100-m w-100-l bio">


### PR DESCRIPTION
## Summary
- add a `.split-row` helper and expand the split-column styles so paired panels stretch and center their copy instead of hugging the bottom of the row
- remove the Tachyons height/alignment utilities on the About, Podcast, and Programs split sections so each column uses the shared flex helpers for full-height layouts
- keep the Programs feature dividers and yellow panels equal to their text columns across breakpoints to prevent overlap

## Testing
- `browser_container.run_playwright_script` (programs mobile screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e02ceb0804832a8827c1c6810ad164