### PR TITLE
Adjust hero blurb spacing to match hero headline

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,11 +34,11 @@
                 </div>
             </div>
             <div class="flex flex-column maincontent w-100">
-                    <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl5-m pl5-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
+                    <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl0-m pl0-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
                         Human creativity
                         <span class="white">has never been more important especially in the face of technology.</span>
                     </div>
-                    <div class="flex items-center flex-row pl3 pl5-m pl5-l w-60 w-20-m w-20-l hero-social">
+                    <div class="flex items-center flex-row pl3 pl0-m pl0-l w-60 w-20-m w-20-l hero-social">
                         <a href="https://open.spotify.com/show/5P6qabdEL76jPmky8eCIWc?si=ed8e0c92cf524fb2" class="h2 w2 social spotify mr3"></a>
                         <a href="https://www.instagram.com/how_to_stay_human/" class="h2 w2 social insta"></a>
                     </div>

--- a/podcast.html
+++ b/podcast.html
@@ -47,11 +47,11 @@
                 </div>
             </div>
             <div class="flex flex-column maincontent w-100">
-                <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl5-m pl5-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
+                <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl0-m pl0-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
                     Human creativity
                     <span class="white">has never been more important especially in the face of technology.</span>
                 </div>
-                <div class="flex items-center flex-row pl3 pl5-m pl5-l w-60 w-20-m w-20-l hero-social">
+                <div class="flex items-center flex-row pl3 pl0-m pl0-l w-60 w-20-m w-20-l hero-social">
                     <a href="https://open.spotify.com/show/5P6qabdEL76jPmky8eCIWc?si=ed8e0c92cf524fb2"
                         class="h2 w2 social spotify mr3"></a>
                     <a href="https://www.instagram.com/how_to_stay_human/" class="h2 w2 social insta"></a>

--- a/programs.html
+++ b/programs.html
@@ -47,11 +47,11 @@
                 </div>
             </div>
             <div class="flex flex-column maincontent w-100">
-                <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl5-m pl5-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
+                <div class="heroblurb pt5 pt5-m pt5-l f5 f4-m f4-l pl3 pl0-m pl0-l pr3 pr0-m pr0-l w-60 w-25-m w-25-l">
                     Human creativity
                     <span class="white">has never been more important especially in the face of technology.</span>
                 </div>
-                <div class="flex items-center flex-row pl3 pl5-m pl5-l w-60 w-20-m w-20-l hero-social">
+                <div class="flex items-center flex-row pl3 pl0-m pl0-l w-60 w-20-m w-20-l hero-social">
                     <a href="https://open.spotify.com/show/5P6qabdEL76jPmky8eCIWc?si=ed8e0c92cf524fb2"
                         class="h2 w2 social spotify mr3"></a>
                     <a href="https://www.instagram.com/how_to_stay_human/" class="h2 w2 social insta"></a>


### PR DESCRIPTION
## Summary
- remove the extra left padding from the hero content wrapper so the blurb lines up with the headline
- add responsive Tachyons padding to the hero blurb and social icons on the about, podcast, and programs pages for consistent alignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e81f777814832a94c2705a5fdc7f4c