### PR TITLE
Adjust hero hero image sizing on medium screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -222,7 +222,8 @@ body {
 
 .heroimage--desktop {
     max-width: none;
-    height: clamp(
+    height: auto;
+    max-height: clamp(
         36rem,
         calc(100vh - var(--hero-header-depth) + 0.5rem),
         calc(100vh - var(--hero-header-depth) + 1.5rem)
@@ -324,7 +325,7 @@ body {
 
     .heroimage--desktop {
         display: block;
-        height: clamp(
+        max-height: clamp(
             38rem,
             calc(100vh - var(--hero-header-depth) + 0.5rem),
             calc(100vh - var(--hero-header-depth) + 1.5rem)
@@ -379,7 +380,7 @@ body {
 
     .heroimage--desktop {
         display: block;
-        height: clamp(
+        max-height: clamp(
             40rem,
             calc(100vh - var(--hero-header-depth) + 0.5rem),
             calc(100vh - var(--hero-header-depth) + 1.5rem)

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                     </div>
             </div>
             <div class="heroimagewrap">
-                <img class="heroimage heroimage--desktop dn db-m db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--desktop dn db-m db-l mw5-m mw-none-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
                 <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">


### PR DESCRIPTION
## Summary
- further limit the desktop hero image to a smaller max width on medium breakpoints using Tachyons helper classes so it stays tucked to the right
- allow the hero image height to remain flexible while keeping the existing viewport-based caps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9328e1b78832aa25d9d1f2021f26c