### PR TITLE
Adjust hero image behavior for medium viewports

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -324,16 +324,11 @@ body {
     }
 
     .heroimage--desktop {
-        display: block;
         max-height: clamp(
             38rem,
             calc(100vh - var(--hero-header-depth) + 0.5rem),
             calc(100vh - var(--hero-header-depth) + 1.5rem)
         );
-    }
-
-    .heroimage--mobile {
-        display: none;
     }
 
     .hero .hero-social {

--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
                     </div>
             </div>
             <div class="heroimagewrap">
-                <img class="heroimage heroimage--desktop dn db-m db-l mw5-m mw-none-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
-                <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--desktop dn db-l mw-none-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--mobile db dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">
                 <div class="bottom-0 bt bb h3 w-100">

--- a/podcast.html
+++ b/podcast.html
@@ -58,8 +58,8 @@
                 </div>
             </div>
             <div class="heroimagewrap">
-                <img class="heroimage heroimage--desktop dn db-m db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
-                <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--desktop dn db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--mobile db dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">
                 <div class="bottom-0 bt bb h3 w-100">

--- a/programs.html
+++ b/programs.html
@@ -58,8 +58,8 @@
                 </div>
             </div>
             <div class="heroimagewrap">
-                <img class="heroimage heroimage--desktop dn db-m db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
-                <img class="heroimage heroimage--mobile db dn-m dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--desktop dn db-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
+                <img class="heroimage heroimage--mobile db dn-l" src="./img/hero.png" alt="Illustration of the How to Stay Human hero" />
             </div>
             <div class="footer w-100">
                 <div class="bottom-0 bt bb h3 w-100">


### PR DESCRIPTION
## Summary
- keep the mobile hero image styling through the medium breakpoint by delaying the desktop swap until large screens
- update hero image markup on each page so Tachyons utility classes no longer hide the mobile artwork at medium widths

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e959ef1d14832a85a5e4d06475e07d