### PR TITLE
Hide duplicate program bumper on mobile

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -306,6 +306,12 @@ body {
     max-width: 34rem;
 }
 
+@media screen and (max-width: 30em) {
+    .desktop-bumper {
+        display: none !important;
+    }
+}
+
 @media screen and (min-width: 30em) {
     .split-row {
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/css/main.css
+++ b/css/main.css
@@ -310,11 +310,19 @@ body {
     .desktop-bumper {
         display: none !important;
     }
+
+    .mobile-order-first {
+        order: -1;
+    }
 }
 
 @media screen and (min-width: 30em) {
     .split-row {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .mobile-order-first {
+        order: 0;
     }
 
     .hero .maincontent {

--- a/programs.html
+++ b/programs.html
@@ -266,10 +266,10 @@
                         </div>
                     </div>
                 </div>
-                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column">
+                <div class="flex w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column mobile-order-first">
                     <div class="split-column__inner bio tl pl3 pl5-m pl5-l pr3 pr5-m pr5-l">
                         <div class="module">
-                            <span class="f6 f5-m f5-l mb1 sectionheading">FIND EVENT IN YOUR AREA</span>    
+                            <span class="f6 f5-m f5-l mb1 sectionheading">FIND EVENT IN YOUR AREA</span>
                             <br />
                             <span class="f3 f2-m f2-l mb1 subtitle mb2">IN PERSON WORKSHOPS</span>
                             <br />

--- a/programs.html
+++ b/programs.html
@@ -194,7 +194,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column dn">
+                <div class="flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column dn desktop-bumper">
                     <div class="flex flex-column split-column__inner bio tl pl3 pl5-m pl5-l pr3 pr5-m pr5-l">
                         <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
                         <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>
@@ -205,7 +205,7 @@
         <!-- 3RD PAGE - GRAHAM -->
         <div class="flex flex-column page nosign bb">
             <div class="split-row flex flex-column flex-row-m flex-row-l" style="flex-grow: 1;">
-                <div class="flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column dn">
+                <div class="flex-m flex-l w-100 w-50-m w-50-l bb br-m br-l bg-yellow split-column dn desktop-bumper">
                     <div class="flex flex-column split-column__inner bio tl pl3 pl5-m pl5-l pr3 pr5-m pr5-l">
                         <span class="f6 f5-m f5-l mb1 sectionheading">30 MINUTE</span>
                         <span class="f3 f2-m f2-l mb1 subtitle mb2">ONLINE MODULES</span>


### PR DESCRIPTION
## Summary
- add a dedicated class to the duplicated "30 minute online modules" bumpers
- hide the desktop-only bumper on small screens to prevent repetition on mobile

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e9619a7f8c832a9f57f865cac6eff7